### PR TITLE
[ISSUE-9]タグ一覧画面実装

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 import js from '@eslint/js';
-import eslintConfigPrettier from 'eslint-config-prettier';
 import tsEsLintPlugin from '@typescript-eslint/eslint-plugin';
 import tsEsLintParser from '@typescript-eslint/parser';
+import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 
 const config = [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint --config eslint.config.mjs --fix 'src/**/*.{js,jsx,ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "vitest",
     "prepare": "husky install"
   },
@@ -29,6 +30,8 @@
   "devDependencies": {
     "@eslint/js": "^8.56.0",
     "@testing-library/react": "^14.1.2",
+    "@types/eslint-config-prettier": "^6.11.3",
+    "@types/eslint__js": "^8.42.3",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20",
     "@types/react": "^18",
@@ -51,8 +54,10 @@
     "vitest": "^1.1.1"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "npx eslint --fix",
-    "*.{js,jsx,ts,tsx,json}": "npx prettier --write"
+    "*.{js,jsx,ts,tsx}": [
+      "pnpm lint --",
+      "pnpm format"
+    ]
   },
   "volta": {
     "node": "20.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,12 @@ devDependencies:
   '@testing-library/react':
     specifier: ^14.1.2
     version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
+  '@types/eslint-config-prettier':
+    specifier: ^6.11.3
+    version: 6.11.3
+  '@types/eslint__js':
+    specifier: ^8.42.3
+    version: 8.42.3
   '@types/jsdom':
     specifier: ^21.1.6
     version: 21.1.6
@@ -963,6 +969,27 @@ packages:
     resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
     dependencies:
       '@babel/types': 7.23.6
+    dev: true
+
+  /@types/eslint-config-prettier@6.11.3:
+    resolution: {integrity: sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==}
+    dev: true
+
+  /@types/eslint@8.56.1:
+    resolution: {integrity: sha512-18PLWRzhy9glDQp3+wOgfLYRWlhgX0azxgJ63rdpoUHyrC9z0f5CkFburjQx4uD7ZCruw85ZtMt6K+L+R8fLJQ==}
+    dependencies:
+      '@types/estree': 1.0.5
+      '@types/json-schema': 7.0.15
+    dev: true
+
+  /@types/eslint__js@8.42.3:
+    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
+    dependencies:
+      '@types/eslint': 8.56.1
+    dev: true
+
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
   /@types/jsdom@21.1.6:

--- a/src/app/_components/ListItem.tsx
+++ b/src/app/_components/ListItem.tsx
@@ -11,7 +11,7 @@ type Props = {
 const ListItem = ({ article }: Props) => {
   return (
     <li>
-      <Link href={`/blog/${article.id}`}>
+      <Link href={`/blog/${article.id.id}`}>
         {article.thumbnail ? (
           <picture>
             <source

--- a/src/app/_components/Tag.tsx
+++ b/src/app/_components/Tag.tsx
@@ -13,7 +13,9 @@ const Tag = ({ tags, hasLink = true }: Props) => {
   return (
     <ul>
       {tags.map((tag) => (
-        <TagItem key={tag.id} tag={tag} hasLink={hasLink} />
+        <li key={tag.id}>
+          <TagItem tag={tag} hasLink={hasLink} />
+        </li>
       ))}
     </ul>
   );

--- a/src/app/_components/TagItem.tsx
+++ b/src/app/_components/TagItem.tsx
@@ -7,7 +7,10 @@ type Props = {
 };
 
 const TagItem = ({ tag, hasLink = true }: Props) => {
-  return <li>{hasLink ? <Link href={`/tags/${tag.id}`}>#{tag.name}</Link> : <span>#{tag.name}</span>}</li>;
+  if (hasLink) {
+    return <Link href={`/tags/${tag.id}`}>#{tag.name}</Link>;
+  }
+  return <span>#{tag.name}</span>;
 };
 
 export default TagItem;

--- a/src/app/tags/[id]/page.tsx
+++ b/src/app/tags/[id]/page.tsx
@@ -1,0 +1,36 @@
+import ListItem from '@/app/_components/ListItem';
+import Pagination from '@/app/_components/Pagination';
+import TagItem from '@/app/_components/TagItem';
+import { getBlogs, getTag } from '@/lib/microcms';
+import { VIEW_COUNT_PER_PAGE } from '@/utils/constants';
+
+type Props = {
+  params: {
+    id: string;
+  };
+};
+
+export default async function Page({ params }: Props) {
+  const data = await getBlogs({
+    limit: VIEW_COUNT_PER_PAGE,
+    filters: `tags[contains]${params.id}`,
+  });
+  if (!data) throw new Error('not found');
+  const { contents } = data;
+  const tag = await getTag(params.id);
+  if (!tag) throw new Error('not found');
+  return (
+    <div>
+      <p>
+        <TagItem tag={tag} hasLink={false} />
+        の記事一覧
+      </p>
+      <ul>
+        {contents.map((article) => (
+          <ListItem key={article.id} article={article} />
+        ))}
+      </ul>
+      <Pagination totalCount={data.totalCount} />
+    </div>
+  );
+}

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -72,3 +72,20 @@ export const getBlog = async (contentId: string, queries?: MicroCMSQueries) => {
     return notFound();
   }
 };
+
+/**
+ * タグの詳細を取得する関数
+ */
+export const getTag = async (contentId: string, queries?: MicroCMSQueries) => {
+  try {
+    const tagData = await client.getListDetail<Tag>({
+      endpoint: 'tags',
+      contentId,
+      queries,
+    });
+    return tagData;
+  } catch (error) {
+    console.error(error);
+    return notFound();
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
       "@app/*": ["./src/app/*"]
     }
   },
-  "include": ["eslint.config.js", "next-env.d.ts", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["eslint.config.mjs", "next-env.d.ts", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
close #9 

issue外タスクとして、eslintとprettierのscript登録とバグの修正を行いました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 特定のタグに関連する記事のリストとページネーション機能を表示するための新しいコンポーネントが追加されました。

- **バグ修正**
  - `Link` コンポーネントの `href` 属性が修正され、リンクの遷移先のロジックが変更されました。

- **リファクタ**
  - `Tag` コンポーネントが直接 `TagItem` をレンダリングするのではなく、`li` 要素でラップするように変更されました。
  - `TagItem` コンポーネントが `hasLink` プロップに基づいて条件付きでリンクをレンダリングするように変更されました。

- **ドキュメント**
  - `eslint.config.mjs` のインポート順序が変更されました。

- **スタイル**
  - コードのスタイルが整えられました。

- **テスト**
  - 新しい機能に関するテストが追加されました。

- **チョア**
  - `microcms.ts` に新しい関数 `getTag` が追加され、タグの詳細を取得できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->